### PR TITLE
Include module and min folders in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "module",
+    "min"
   ],
   "scripts": {
     "lint": "eslint src/**",


### PR DESCRIPTION
Been looking for a package like this for a long time! I specifically need the `mix` function, preferably as an ES module. I noticed you had ES modules but the package.json settings were preventing them from being published on NPM.